### PR TITLE
Rough in Tasks, update Sidekiq deployment

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Task encapsulates things that occur on a recurring
+# basis, including scheduling, next run time, last run time,
+# etc.
+#
+# Subclass the Task class to do something specific.
+# Conversely, don't invoke this base class directly.
+#
+class Task < ApplicationRecord
+  belongs_to :taskable, polymorphic: true
+
+  # Require a key
+  validates_presence_of :key
+
+  # Prevent duplicate keys for a given Taskable
+  validates_uniqueness_of :key, scope: :taskable
+
+  # override `perform` in subclasses. Make
+  # sure to call `super` in subclasses or, alternately,
+  # call set_high_watermark from subclasses
+  def perform
+    set_high_watermark
+  end
+
+  # if we're calling every minute, most of the time there's nothing to do
+  #
+  def perform_on_schedule
+    perform if time_to_run?
+  end
+
+  # set `last_ran_at`
+  #
+  def set_high_watermark
+    update! last_ran_at: DateTime.now
+  end
+
+  # When should it run next? Returns a DateTime
+  def next_runs_at
+    schedule.next_occurrence(last_ran_at || 1.week.ago)
+  end
+
+  def time_to_run?
+    DateTime.now.after?(next_runs_at)
+  end
+
+  def schedule
+    @schedule ||= schedule_hash.present? ? IceCube::Schedule.from_hash(schedule_hash) : IceCube::Schedule.new
+  end
+
+  # Entrypoint for cron or other task runner: Task.perform_all. The assumption
+  # is that this gets called frequently (e.g. every 60 seconds).
+  #
+  # It iterates across all jobs, calling perform_on_schedule for each.
+  #
+  def self.perform_all
+    return if @@running
+
+    @running = true
+    Task.all.each(&:perform_on_schedule)
+    @running = false
+  end
+end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -7,6 +7,7 @@ class Unit < ApplicationRecord
   has_many :unit_memberships
   has_many :users, through: :unit_memberships
   has_many :news_items
+  has_many :tasks, as: :taskable
   has_one_attached :logo
 
   validates_presence_of :name

--- a/app/models/unit_digest_task.rb
+++ b/app/models/unit_digest_task.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Subclass for sending unit digests to members
+class UnitDigestTask < Task
+end

--- a/config/kube/sidekiq.yml
+++ b/config/kube/sidekiq.yml
@@ -18,25 +18,20 @@ spec:
       labels:
         app: scoutplan-sidekiq
     spec:
-      # initContainers:
-      # - name: migrations
-      #   image: registry.digitalocean.com/scoutplan/app
-      #   command:
-      #   - rake
-      #   - db:abort_if_pending_migrations
       containers:
         - name: scoutplan-sidekiq
           image: registry.digitalocean.com/scoutplan/app
-          command: ["sidekiq"]
+          command:
+            - bundle
+            - exec
+            - sidekiq
           imagePullPolicy: "Always"
           # readinessProbe:
           #   httpGet:
           #     path: /
-          #     port: 3000
-          #     scheme: HTTP
+          #     port: 7433
           #   initialDelaySeconds: 60
-          #   periodSeconds: 30
-          #   timeoutSeconds: 60
+          #   timeoutSeconds: 10
           env:
             - name: DATABASE_PASSWORD
               valueFrom:

--- a/db/migrate/20220102221416_create_tasks.rb
+++ b/db/migrate/20220102221416_create_tasks.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# migration to create Task schema
+class CreateTasks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tasks do |t|
+      t.string      :key, null: false
+      t.text        :schedule_hash
+      t.string      :type, null: false
+      t.datetime    :last_ran_at
+      t.references  :taskable, null: false, polymorphic: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_15_194731) do
+ActiveRecord::Schema.define(version: 2022_01_02_221416) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2021_11_15_194731) do
     t.text "metadata"
     t.string "service_name", null: false
     t.bigint "byte_size", null: false
-    t.string "checksum", null: false
+    t.string "checksum"
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -162,6 +162,18 @@ ActiveRecord::Schema.define(version: 2021_11_15_194731) do
     t.datetime "updated_at"
     t.index ["target_type", "target_id", "var"], name: "index_settings_on_target_type_and_target_id_and_var", unique: true
     t.index ["target_type", "target_id"], name: "index_settings_on_target"
+  end
+
+  create_table "tasks", force: :cascade do |t|
+    t.string "key", null: false
+    t.text "schedule_hash"
+    t.string "type", null: false
+    t.datetime "last_ran_at", precision: 6
+    t.string "taskable_type", null: false
+    t.bigint "taskable_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["taskable_type", "taskable_id"], name: "index_tasks_on_taskable"
   end
 
   create_table "unit_memberships", force: :cascade do |t|

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :task do
+    
+  end
+end

--- a/spec/models/digest_sender_spec.rb
+++ b/spec/models/digest_sender_spec.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-def schedule_yaml
-  "---\n:start_time: 2021-12-12 12:55:41.000000000 -05:00\n:rrules:\n- :validations:\n    :day:\n    - 1\n    :hour_of_day:\n    - 7\n    :minute_of_hour:\n    - 0\n    :second_of_minute:\n    - 0\n  :rule_type: IceCube::WeeklyRule\n  :interval: 1\n  :week_start: 0\n:rtimes: []\n:extimes: []\n"
-end
-
-def schedule
+def the_schedule
   result = IceCube::Schedule.new
   result.add_recurrence_rule IceCube::Rule.weekly.day(0).hour_of_day(7)
   result
@@ -19,7 +15,7 @@ RSpec.describe DigestSender, type: :model do
   describe "time_to_run" do
     before do
       @unit = FactoryBot.create(:unit)
-      @unit.settings(:communication).update! digest_schedule: schedule.to_hash
+      @unit.settings(:communication).update! digest_schedule: the_schedule.to_hash
       @sender = DigestSender.new
       @sender.unit = @unit
     end
@@ -46,7 +42,7 @@ RSpec.describe DigestSender, type: :model do
       @unit = @member.unit
 
       # enable digest for the unit
-      @unit.settings(:communication).update! digest_schedule: schedule.to_hash
+      @unit.settings(:communication).update! digest_schedule: the_schedule.to_hash
 
       # enable digest for the member
       Flipper.enable_actor :digest, @member

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class TestTask < Task; end
+
+def schedule
+  IceCube::Schedule
+    .new
+    .add_recurrence_rule IceCube::Rule.weekly.day(0).hour_of_day(7)
+end
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe Task, type: :model do
+  it "instantiates" do
+    expect { Task.new }.not_to raise_exception
+  end
+
+  describe "validations" do
+    before do
+      @unit = FactoryBot.create(:unit)
+    end
+
+    it "requires a key" do
+      expect(@unit.tasks.new(type: "TestTask", key: nil)).not_to be_valid
+    end
+
+    it "prevents duplicate keys" do
+      key_name = "shazam!"
+      task = @unit.tasks.create(type: "TestTask", key: key_name)
+      expect(task).to be_valid
+      expect(@unit.tasks.new(type: "TestTask", key: key_name)).not_to be_valid
+    end
+  end
+
+  describe "time_to_run" do
+    before do
+      @task = Task.new
+      @task.schedule.add_recurrence_rule IceCube::Rule.weekly.day(0).hour_of_day(7)
+    end
+
+    it "returns true when it's a week from now" do
+      Timecop.freeze(DateTime.now.sunday + 7.days)
+      expect(@task.time_to_run?).to be_truthy
+      Timecop.return
+    end
+
+    it "returns false when it's a week ago" do
+      Timecop.freeze(DateTime.now.sunday - 14.days)
+      expect(@task.time_to_run?).to be_falsey
+      Timecop.return
+    end
+  end
+
+  describe "set high watermark" do
+    before do
+      @unit = FactoryBot.create(:unit)
+      @task = @unit.tasks.create(key: "digest", type: "TestTask")
+    end
+
+    it "persists last runtime" do
+      @task.set_high_watermark
+      @task.reload
+      expect(@task.last_ran_at).to be_within(1.second).of DateTime.now
+    end
+
+    it "sets high watermark after perform" do
+      @task.perform
+      @task.reload
+      expect(@task.last_ran_at).to be_within(1.second).of DateTime.now
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
- Tasks will eventually replace and encapsulate the currently distributed schedule task logic. Here, we're just roughing in the base class.
- Per pending Github issue, the fix for the broken Sidekiq deployment is to launch via "bundle exec"...this does that.