### PR TITLE
iCal improvements

### DIFF
--- a/app/models/ical_exporter.rb
+++ b/app/models/ical_exporter.rb
@@ -6,22 +6,25 @@ require "icalendar"
 class IcalExporter
   attr_accessor :event
 
-  def initialize(member)
+  def initialize(member, event = nil)
     @member = member
+    self.event = event
   end
 
   # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def to_ical
-    event = Icalendar::Event.new
-    event.summary = @event.title
-    event.summary += " (DRAFT)" if @event.draft?
-    event.summary += " (CANCELLED)" if @event.cancelled?
-    event.dtstart = @event.starts_at.in_time_zone(@event.unit.time_zone)
-    event.dtend = @event.ends_at.in_time_zone(@event.unit.time_zone)
-    event.location = [@event.location.presence, @event.address.presence].compact.join(" ")
-    event.description = @event.description&.to_plain_text || @event.short_description
-    event.url = Rails.application.routes.url_helpers.unit_event_url(@event.unit, @event, host: ENV["APP_HOST"])
-    event
+    ical_event = Icalendar::Event.new
+    ical_event.summary = "#{@event.unit.short_name} - #{@event.title}"
+    ical_event.summary += " (DRAFT)" if @event.draft?
+    ical_event.summary += " (CANCELLED)" if @event.cancelled?
+    ical_event.dtstart = @event.starts_at.in_time_zone(@event.unit.time_zone)
+    ical_event.dtend = @event.ends_at.in_time_zone(@event.unit.time_zone)
+    ical_event.location = [@event.location.presence, @event.address.presence].compact.join(" ")
+    ical_event.description = @event.description&.to_plain_text || @event.short_description
+    ical_event.url = Rails.application.routes.url_helpers.unit_event_url(@event.unit, @event, host: ENV["APP_HOST"])
+    ical_event
   end
   # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/models/ical_exporter.rb
+++ b/app/models/ical_exporter.rb
@@ -15,6 +15,7 @@ class IcalExporter
     event = Icalendar::Event.new
     event.summary = @event.title
     event.summary += " (DRAFT)" if @event.draft?
+    event.summary += " (CANCELLED)" if @event.cancelled?
     event.dtstart = @event.starts_at.in_time_zone(@event.unit.time_zone)
     event.dtend = @event.ends_at.in_time_zone(@event.unit.time_zone)
     event.location = [@event.location.presence, @event.address.presence].compact.join(" ")

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -41,14 +41,6 @@ class Unit < ApplicationRecord
     Message.where(author_id: members.collect(&:id))
   end
 
-  def to_param
-    [id, name, location].join(" ").parameterize
-  end
-
-  def to_s
-    name
-  end
-
   def membership_for(user)
     members.includes(:parent_relationships, :child_relationships).find_by(user: user)
   end
@@ -61,8 +53,20 @@ class Unit < ApplicationRecord
     categories.first
   end
 
+  def short_name
+    name.split.map { |word| word.numeric? ? word : word.first }.join
+  end
+
   def time_zone
     settings(:locale).time_zone
+  end
+
+  def to_param
+    [id, name, location].join(" ").parameterize
+  end
+
+  def to_s
+    name
   end
 
   private

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative 'boot'
+require_relative "boot"
 
-require 'rails/all'
+require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/integer/time"
-
 # rubocop:disable Metrics/BlockLength
 Rails.application.configure do
   config.web_console.permissions = "172.0.0.0/8"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/integer/time"
-
 Rails.application.default_url_options = {
   host: ENV["SCOUTPLAN_HOST"],
   protocol: ENV["SCOUTPLAN_PROTOCOL"]

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/integer/time"
-
 # The test environment is used exclusively to run your application"s
 # test suite. You never need to work with it otherwise. Remember that
 # your test database is "scratch space" for the test suite and is wiped

--- a/config/initializers/core_ext.rb
+++ b/config/initializers/core_ext.rb
@@ -1,1 +1,0 @@
-Dir[File.join(Rails.root, "lib", "core_ext", "*.rb")].each {|l| require l }

--- a/config/initializers/core_extensions.rb
+++ b/config/initializers/core_extensions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Dir[Rails.root.join("lib", "core_ext", "string", "*.rb")].each { |f| require f }
+Dir[Rails.root.join("lib", "core_ext", "time", "*.rb")].each { |f| require f }
+
+String.include CoreExtensions::String::TestMethods
+Time.include CoreExtensions::Time::ToWords

--- a/lib/core_ext/string/test_methods.rb
+++ b/lib/core_ext/string/test_methods.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# monkey-patch String with new method
+
+module CoreExtensions
+  module String
+    # boolean method(s) additions to String
+    module TestMethods
+      # rubocop:disable Style/RescueModifier
+      # re-open String and add a numeric? method to it
+      def numeric?
+        true if Float(self) rescue false
+      end
+      # rubocop:enable Style/RescueModifier
+    end
+  end
+end

--- a/lib/core_ext/time.rb
+++ b/lib/core_ext/time.rb
@@ -1,7 +1,0 @@
-class Time
-  def time_of_day
-    return 'evening' if hour > 18
-    return 'morning' if hour < 12
-    return 'afternoon'
-  end
-end

--- a/lib/core_ext/time/to_words.rb
+++ b/lib/core_ext/time/to_words.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module CoreExtensions
+  module Time
+    # new Time method(s) for displaying words in the GUI
+    module ToWords
+      # time_of_day method returns things like "morning"
+      def time_of_day
+        return "evening" if hour > 18
+
+        return "morning" if hour < 12
+
+        "afternoon"
+      end
+    end
+  end
+end

--- a/spec/features/event_icalendar_spec.rb
+++ b/spec/features/event_icalendar_spec.rb
@@ -44,7 +44,7 @@ describe "events", type: :feature do
 
       # expect(cal_event.dtstart.to_datetime).to be_within(1.second).of event.starts_at
       # expect(cal_event.dtstart.to_datetime.utc).to be_within(1.second).of event.starts_at.to_datetime
-      expect(cal_event.summary).to eq(event.title)
+      expect(cal_event.summary.to_s).to eq("#{@unit.short_name} - #{event.title}")
       expect(cal_event.location).to eq(event.location)
       expect(cal_event.description).to eq(event.description.to_plain_text)
       expect(cal_event.url.to_s).not_to be_empty

--- a/spec/models/ical_exporter_spec.rb
+++ b/spec/models/ical_exporter_spec.rb
@@ -2,48 +2,53 @@
 
 require "rails_helper"
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe IcalExporter, type: :model do
   before do
     @member = FactoryBot.create(:member)
-    @exporter = IcalExporter.new(@member)
+    @unit = @member.unit
+    @event = FactoryBot.create(:event, unit: @member.unit)
+    @exporter = IcalExporter.new(@member, @event)
+  end
+
+  describe "event name" do
+    it "prepends the unit's short name" do
+      @ical_event = @exporter.to_ical
+      expect(@ical_event.summary).to start_with(@unit.short_name)
+    end
+
+    it "appends DRAFT events" do
+      @exporter.event.status = :draft
+      @ical_event = @exporter.to_ical
+      expect(@ical_event.summary).to end_with("(DRAFT)")
+    end
+
+    it "appends CANCELLED events" do
+      @exporter.event.status = :cancelled
+      @ical_event = @exporter.to_ical
+      expect(@ical_event.summary).to end_with("(CANCELLED)")
+    end
   end
 
   describe "location" do
     it "includes the location field when present" do
-      @event = FactoryBot.create(:event, :with_location)
-      @exporter.event = @event
-      ical_event = @exporter.to_ical
-      expect(ical_event.location).to eq(@event.location)
+      @exporter.event.location = "A location"
+      @ical_event = @exporter.to_ical
+      expect(@ical_event.location).to eq(@event.location)
     end
 
     it "includes the address when present" do
-      @event = FactoryBot.create(:event, :with_address)
-      @exporter.event = @event
-      ical_event = @exporter.to_ical
-      expect(ical_event.location).to eq(@event.address)
+      @event.address = "An address"
+      @ical_event = @exporter.to_ical
+      expect(@ical_event.location).to eq(@event.address)
     end
 
     it "includes the location and address when both as present" do
-      @event = FactoryBot.create(:event, :with_location, :with_address)
-      @exporter.event = @event
-      ical_event = @exporter.to_ical
-      expect(ical_event.location).to eq("#{@event.location} #{@event.address}")
-    end
-
-    it "appends DRAFT events" do
-      @event = FactoryBot.create(:event, :with_location, :with_address)
-      @exporter.event = @event
-      @event.status = :draft
-      ical_event = @exporter.to_ical
-      expect(ical_event.summary).to end_with("(DRAFT)")
-    end
-
-    it "appends CANCELLED events" do
-      @event = FactoryBot.create(:event, :with_location, :with_address)
-      @exporter.event = @event
-      @event.status = :cancelled
-      ical_event = @exporter.to_ical
-      expect(ical_event.summary).to end_with("(CANCELLED)")
+      @event.location = "A location"
+      @event.address = "An address"
+      @ical_event = @exporter.to_ical
+      expect(@ical_event.location).to eq("#{@event.location} #{@event.address}")
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/models/ical_exporter_spec.rb
+++ b/spec/models/ical_exporter_spec.rb
@@ -29,5 +29,21 @@ RSpec.describe IcalExporter, type: :model do
       ical_event = @exporter.to_ical
       expect(ical_event.location).to eq("#{@event.location} #{@event.address}")
     end
+
+    it "appends DRAFT events" do
+      @event = FactoryBot.create(:event, :with_location, :with_address)
+      @exporter.event = @event
+      @event.status = :draft
+      ical_event = @exporter.to_ical
+      expect(ical_event.summary).to end_with("(DRAFT)")
+    end
+
+    it "appends CANCELLED events" do
+      @event = FactoryBot.create(:event, :with_location, :with_address)
+      @exporter.event = @event
+      @event.status = :cancelled
+      ical_event = @exporter.to_ical
+      expect(ical_event.summary).to end_with("(CANCELLED)")
+    end
   end
 end

--- a/spec/models/string_spec.rb
+++ b/spec/models/string_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Dir[Rails.root.join("lib", "core_ext", "string", "*.rb")].each { |f| require f }
+String.include CoreExtensions::String::TestMethods
+
+# monkey-patched String class
+class String
+  describe "numeric?" do
+    it "returns true when string is numeric" do
+      expect("123".numeric?).to be_truthy
+    end
+
+    it "returns false when string is not numeric" do
+      expect("Troop".numeric?).to be_falsey
+    end
+  end
+end

--- a/spec/models/unit_spec.rb
+++ b/spec/models/unit_spec.rb
@@ -1,43 +1,51 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Unit, type: :model do
-  it 'has a valid base factory' do
+  it "has a valid base factory" do
     expect(FactoryBot.build(:unit)).to be_valid
   end
 
-  it 'has a valid factory with members' do
+  it "has a valid factory with members" do
     expect(FactoryBot.build(:unit_with_members)).to be_valid
   end
 
-  context 'callbacks' do
-    it 'creates default categories' do
-      EventCategory.create(name: 'Troop Meeting')
-      EventCategory.create(name: 'Camping')
-      EventCategory.create(name: 'Court of Honor')
+  context "callbacks" do
+    it "creates default categories" do
+      EventCategory.create(name: "Troop Meeting")
+      EventCategory.create(name: "Camping")
+      EventCategory.create(name: "Court of Honor")
 
       @category_count = EventCategory.seeds.count
 
-      unit = Unit.create(name: 'Troop 1234')
+      unit = Unit.create(name: "Troop 1234")
 
       # unit = FactoryBot.create(:unit)
       expect(unit.event_categories.count).to eq(@category_count)
     end
   end
 
-  context 'validations' do
-    it 'requires a name' do
+  context "validations" do
+    it "requires a name" do
       expect(FactoryBot.build(:unit, name: nil)).not_to be_valid
     end
   end
 
-  context 'methods' do
-    it 'finds a membership for a user' do
-      membership = FactoryBot.create(:unit_membership)
-      unit = membership.unit
-      user = membership.user
-      expect(unit.membership_for(user)).to eq(membership)
+  context "methods" do
+    before do
+      @member = FactoryBot.create(:member)
+      @unit = @member.unit
+      @user = @member.user
+    end
+
+    it "finds a membership for a user" do
+      expect(@unit.membership_for(@user)).to eq(@member)
+    end
+
+    it "renders a short name correctly" do
+      @unit.name = "Troop 123"
+      expect(@unit.short_name).to eq("T123")
     end
   end
 end


### PR DESCRIPTION
- Add CANCELLED to cancelled event names (which only admins see anyway)
- Prepend unit identifier to event names ("e.g. Hiking Trip becomes "T123 - Hiking Trip" for Troop 123)
- Refactor monkey patches for clarity
- Under-the-hood methods to support the foregoing (e.g. Unit#short_name), which converts Troop 123 => T123