### PR TITLE
Update Github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ main ]
+    branches: [ current_deployment ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
'current_deployment' branch now kicks off Github deployment action. Fixes #532.

Old flow: dev > pre-prod > main
New flow: dev > main > current_deployment