### PR TITLE
Bring back inline location create (#727)

### DIFF
--- a/app/views/locations/edit.html.slim
+++ b/app/views/locations/edit.html.slim
@@ -21,6 +21,7 @@
 
     = render partial: "form", locals: { unit: @unit, location: @location }
 
+
     .absolute.right-0.bottom-0.pb-2.items-center
       = button_to unit_location_path(@unit, @location),
                   method: "delete",

--- a/app/views/locations/new.html.slim
+++ b/app/views/locations/new.html.slim
@@ -1,5 +1,6 @@
 = turbo_frame_tag "main"
   .mx-auto.max-w-xl
+
     header
       = link_to return_path ||= unit_locations_path(@unit),
           class: "text-center font-bold no-underline inline-block w-full md:w-fit py-3 md:py-2 text-brand-500 hover:text-brand-600",
@@ -13,5 +14,4 @@
           = "Back to address book"
 
     = render partial: "form",
-             locals: { unit: @unit, location: @location, event_id: params[:event_id],
-                       location_type: params[:location_type] }
+             locals: { unit: @unit, location: @location, event_id: params[:event_id], location_type: params[:location_type] }


### PR DESCRIPTION
* Light UI refactor of Events page

* Inline event creation feature complete

* Fix calendar view so it shows all events. Fixes #720.

* Roughed in SMS response for #701

* Add Cancel link to location edit page

* Clean up location form

* Inline event creation feature complete

* Resolved conflicts

* Resolve conflict