### PR TITLE
Return to previous schedule view from Event

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -10,9 +10,10 @@ require "humanize"
 # rubocop:disable Metrics/CyclomaticComplexity
 class EventsController < UnitContextController
   skip_before_action :authenticate_user!, only: [:public]
-  before_action :find_event, except: %i[index list calendar spreadsheet create new bulk_publish public my_rsvps signups]
+  before_action :find_event, except: %i[list calendar spreadsheet create new bulk_publish public my_rsvps signups]
   before_action :collate_rsvps, only: [:show, :rsvps]
   before_action :set_calendar_dates, only: [:calendar, :list]
+  before_action :remember_unit_events_path, only: [:list, :calendar]
   layout :current_layout
 
   def calendar
@@ -428,6 +429,10 @@ class EventsController < UnitContextController
     scope = scope.offset((@page - 1).abs * page_size).limit(page_size)
     scope = scope.published unless EventPolicy.new(current_member, @unit).view_drafts?
     @events = scope.all.reverse
+  end
+
+  def remember_unit_events_path
+    session[:events_index_path] = request.original_fullpath
   end
 
   def scope_for_list

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,6 +64,10 @@ module ApplicationHelper
     pill_tag_if(number.positive?, number, additional_classes)
   end
 
+  def remembered_unit_events_path(unit)
+    session[:events_index_path] || unit_events_path(unit)
+  end
+
   # given a member, return the appropriate FontAwesome element tag
   def member_glyph_tag(member)
     colors = {

--- a/app/views/events/partials/show/_header.slim
+++ b/app/views/events/partials/show/_header.slim
@@ -1,6 +1,6 @@
 header.relative.mb-4
   .mb-4
-    = link_to unit_events_path(@unit),
+    = link_to remembered_unit_events_path(@unit),
       class: "inline-block py-3 rounded font-bold text-cyan-600",
       data: { turbo_action: "advance" } do
 

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -116,6 +116,16 @@ describe "events", type: :feature do
         visit(path)
         expect(page).not_to have_content(@event.starts_at.strftime("%-I:%M %p"))
       end
+
+      it "returns to the previous view" do
+        event2 = FactoryBot.create(:event, :published, unit: @unit, starts_at: 1.month.from_now, ends_at: 1.month.from_now + 1.hour)
+        path = calendar_unit_events_path(@unit, year: 1.month.from_now.year, month: 1.month.from_now.month)
+        visit(path)
+
+        click_link(event2.title)
+        click_link("Event schedule")
+        expect(page).to have_current_path(path)
+      end
     end
 
     describe "update" do


### PR DESCRIPTION
- When returning from viewing a single Event, user will now be redirected to their previous view, either list or calendar
- If returning to calendar, they'll be returned to the month and year they were previously viewing, instead of the current month and year
- This is helpful during planning and data entry exercises
- Completes #1459