### PR TITLE
Identity bug

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,7 +21,8 @@ class EventsController < UnitContextController
     end
 
     scope = @unit.events
-    scope = scope.published unless EventPolicy.new(current_member, @unit).view_drafts?
+    # scope = scope.published unless EventPolicy.new(current_member, @unit).view_drafts?
+    scope = scope.published unless @current_member.role == "admin"
     scope = scope.where("starts_at BETWEEN ? AND ?", @start_date, @end_date)
     @events = scope.all
   end

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -12,7 +12,8 @@ describe "events", type: :feature do
     @normal_user = FactoryBot.create(:user, email: "test_normal@scoutplan.org")
 
     @unit  = FactoryBot.create(:unit)
-    @event = FactoryBot.create(:event, :draft, unit: @unit, title: "Draft Event")
+    @draft_event = FactoryBot.create(:event, :draft, unit: @unit, title: "Draft Event")
+    @published_event = FactoryBot.create(:event, :published, unit: @unit, title: "Published Event")
 
     @admin_member = @unit.memberships.create(user: @admin_user, role: "admin", status: :active)
     @normal_member = @unit.memberships.create(user: @normal_user, role: "member", status: :active)
@@ -80,16 +81,32 @@ describe "events", type: :feature do
       end
     end
 
+    describe "list" do
+      it "hides drafts for non-admins" do
+        login_as(@normal_member.user, scope: :user)
+
+        visit list_unit_events_path(@unit)
+        expect(page).to have_content(@published_event.title)
+        expect(page).not_to have_content(@draft_event.title)
+      end
+
+      it "shows drafts for admins" do
+        visit list_unit_events_path(@unit)
+        expect(page).to have_content(@published_event.title)
+        expect(page).to have_content(@draft_event.title)
+      end
+    end
+
     describe "show" do
       it "accesses drafts" do
-        visit(path = unit_event_path(@unit, @event))
+        visit(path = unit_event_path(@unit, @draft_event))
         expect(page).to have_current_path(path)
       end
 
       it "shows an Event with a location" do
         location = FactoryBot.create(:location, unit: @unit)
-        @event.event_locations.create(location: location, location_type: :arrival)
-        path = unit_event_path(@unit, @event)
+        @draft_event.event_locations.create(location: location, location_type: :arrival)
+        path = unit_event_path(@unit, @draft_event)
         visit(path)
         expect(page).to have_current_path(path)
       end
@@ -103,44 +120,44 @@ describe "events", type: :feature do
       it "does not display Cancel link on cancelled events" do
         skip
 
-        @event.update!(status: :cancelled)
-        visit edit_unit_event_path(@unit, @event)
+        @draft_event.update!(status: :cancelled)
+        visit edit_unit_event_path(@unit, @draft_event)
         expect(page).not_to have_link(I18n.t("events.show.cancel_title"))
       end
 
       it "hides times for all-day events" do
-        path = unit_event_path(@unit, @event)
+        path = unit_event_path(@unit, @draft_event)
         visit(path)
-        expect(page).to have_content(@event.starts_at.strftime("%-I:%M %p"))
-        @event.update!(all_day: true)
+        expect(page).to have_content(@draft_event.starts_at.strftime("%-I:%M %p"))
+        @draft_event.update!(all_day: true)
         visit(path)
-        expect(page).not_to have_content(@event.starts_at.strftime("%-I:%M %p"))
+        expect(page).not_to have_content(@draft_event.starts_at.strftime("%-I:%M %p"))
       end
     end
 
     describe "update" do
       it "updates an event" do
-        visit edit_unit_event_path(@unit, @event)
-        expect(page).to have_current_path(edit_unit_event_path(@unit, @event))
+        visit edit_unit_event_path(@unit, @draft_event)
+        expect(page).to have_current_path(edit_unit_event_path(@unit, @draft_event))
 
         fill_in :event_title, with: "New Event Title"
         click_button "Save Changes"
 
-        @event.reload
-        expect(page).to have_current_path(unit_event_path(@unit, @event))
+        @draft_event.reload
+        expect(page).to have_current_path(unit_event_path(@unit, @draft_event))
       end
 
       it "updates all day" do
         skip
-        visit edit_unit_event_path(@unit, @event)
+        visit edit_unit_event_path(@unit, @draft_event)
 
         find(css: "#event_all_day").click
 
         # check "#event_all_day", allow_label_click: true
         click_button "Save Changes"
 
-        @event.reload
-        expect(@event.all_day).to be_truthy
+        @draft_event.reload
+        expect(@draft_event.all_day).to be_truthy
       end
     end
   end
@@ -152,10 +169,10 @@ describe "events", type: :feature do
     it "can access the event page page" do
       login_as(@normal_member.user, scope: :user)
 
-      expect { @event.event_organizers.create!(unit_membership: @normal_member, assigned_by: @admin_member) }.to change { @event.organizers.count }.by(1)
-      expect(@event.organizer?(@normal_member)).to be_truthy
-      visit unit_event_path(@unit, @event)
-      expect(page).to have_current_path(unit_event_path(@unit, @event))
+      expect { @draft_event.event_organizers.create!(unit_membership: @normal_member, assigned_by: @admin_member) }.to change { @draft_event.organizers.count }.by(1)
+      expect(@draft_event.organizer?(@normal_member)).to be_truthy
+      visit unit_event_path(@unit, @draft_event)
+      expect(page).to have_current_path(unit_event_path(@unit, @draft_event))
     end
   end
 
@@ -165,13 +182,13 @@ describe "events", type: :feature do
     end
 
     it "prevents access a draft Event page" do
-      path = unit_event_path(@unit, @event)
+      path = unit_event_path(@unit, @draft_event)
       visit path
       expect(page).to have_current_path(list_unit_events_path(@unit))
     end
 
     it "prevents access to the Organize page" do
-      visit unit_event_rsvps_path(@unit, @event)
+      visit unit_event_rsvps_path(@unit, @draft_event)
       expect(page).to have_current_path(list_unit_events_path(@unit))
     end
 


### PR DESCRIPTION
- Temporarily avoid calling into EventPolicy in Events#list on the theory that the policy object is somehow mutating the current user's identity
- Authored new specs to ensure that the above workaround doesn't expose events that it ought not to