### PR TITLE
Skylight config

### DIFF
--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -6,3 +6,4 @@ ignored_endpoints:
   - Blazer::QueriesController#destroy
   - Blazer::DashboardsController#show
   - Blazer::QueriesController#cancel
+  - CalendarController#index


### PR DESCRIPTION
- Omit CalendarController#index as an endpoint
- It's slow and that's okay. No need to have Skylight complain to us about it