### PR TITLE
Generate static event maps

### DIFF
--- a/app/jobs/generate_event_static_map_job.rb
+++ b/app/jobs/generate_event_static_map_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class GenerateEventStaticMapJob < ApplicationJob
+  queue_as :default
+
+  def perform(event_id)
+    event = Event.find(event_id)
+    event.generate_static_map
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,7 +3,8 @@
 # a calendar event
 # rubocop:disable Metrics/ClassLength
 class Event < ApplicationRecord
-  include Notifiable, Remindable, Onlineable, Icalendarable, Replyable, Invitations, DatePresentable
+  include Notifiable, Remindable, Onlineable, Icalendarable, Replyable, Invitations,
+          DatePresentable, StaticMappable
   extend DateTimeAttributes
 
   date_time_attrs_for :starts_at, :ends_at
@@ -42,6 +43,7 @@ class Event < ApplicationRecord
 
   has_rich_text :description
 
+  has_one_attached :static_map
   has_many_attached :attachments
 
   has_paper_trail versions: { scope: -> { order("id desc") } }

--- a/app/models/event/static_mappable.rb
+++ b/app/models/event/static_mappable.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Event::StaticMappable
+  extend ActiveSupport::Concern
+
+  MAP_BASE_URL = "https://maps.googleapis.com/maps/api/staticmap"
+  MAP_SIZE     = "500x300"
+  MAP_ZOOM     = 10
+  MAP_FILENAME = "map.png"
+
+  def enqueue_static_map_job
+    GenerateEventStaticMapJob.perform_later(id)
+  end
+
+  def generate_static_map
+    return unless map_address.present?
+
+    downloaded_image = URI.parse(map_url).open
+    static_map.attach(io: downloaded_image, filename: MAP_FILENAME)
+  end
+
+  def map_url
+    query = CGI.escape(map_address.gsub(",", ""))
+    params = "key=#{ENV.fetch('GOOGLE_API_KEY', nil)}&center=#{query}&zoom=#{MAP_ZOOM}&size=#{MAP_SIZE}"
+    "#{MAP_BASE_URL}?#{params}"
+  end
+end

--- a/app/models/event_location.rb
+++ b/app/models/event_location.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
-# join Model between Events and Location
 class EventLocation < ApplicationRecord
   belongs_to :event
   belongs_to :location
   validates_uniqueness_of :location_type, scope: [:event, :location]
+
+  after_save :enqueue_static_map_job
+
+  def enqueue_static_map_job
+    GenerateEventStaticMapJob.perform_later(event.id)
+  end
 end

--- a/lib/tasks/generate_static_event_maps.rake
+++ b/lib/tasks/generate_static_event_maps.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :sp do
+  desc "Generate static maps for all events"
+  task generate_static_event_maps: :environment do
+    events = Event.all
+    events.each(&:enqueue_static_map_job)
+    puts "Enqueued #{events.count} static map jobs"
+  end
+end

--- a/spec/jobs/generate_event_static_map_job_spec.rb
+++ b/spec/jobs/generate_event_static_map_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe GenerateEventStaticMapJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
- Creation / update of a EventLocation object kick off an asynchronous job
- New attachment attribute on Event
- Job calls into Event to retrieve a static image from the Google Static Maps API
- Image is attached to Event
- Rake task for generating static images for all Events