### PR TITLE
Enable RSVP digest for arbitrary members

### DIFF
--- a/app/controllers/unit_memberships_controller.rb
+++ b/app/controllers/unit_memberships_controller.rb
@@ -1,6 +1,4 @@
-# frozen_string_literal: true
-
-# responsible for Unit <> User relationships
+# rubocop:disable Metrics/ClassLength
 class UnitMembershipsController < ApplicationController
   before_action :find_unit, only: %i[index new create bulk_update invite]
   before_action :find_membership, except: %i[index new create bulk_update]
@@ -32,17 +30,20 @@ class UnitMembershipsController < ApplicationController
     page_title [@unit.name, @user.full_display_name]
   end
 
+  # rubocop:disable Metrics/AbcSize
   def create
     find_or_create_user
 
     @member = @unit.memberships.new(member_params)
     @member.user_id = @user.id
     return unless @member.save!
+
     MemberRelationshipService.new(@member).update(params[:member_relationships])
 
     flash[:notice] = t("members.confirmations.create", member_name: @member.full_display_name, unit_name: @unit.name)
     redirect_to unit_members_path(@unit)
   end
+  # rubocop:enable Metrics/AbcSize
 
   def find_or_create_user
     @user = User.create_with(
@@ -101,7 +102,8 @@ class UnitMembershipsController < ApplicationController
   private
 
   def find_membership
-    @target_membership = UnitMembership.includes(:parent_relationships, :child_relationships).find(params[:member_id] || params[:id])
+    @target_membership = UnitMembership.includes(:parent_relationships,
+                                                 :child_relationships).find(params[:member_id] || params[:id])
     @target_user = @target_membership.user
     @current_unit = @unit = @target_membership.unit
     @current_member = @unit.membership_for(current_user)
@@ -115,9 +117,9 @@ class UnitMembershipsController < ApplicationController
   def member_params
     params.require(:unit_membership).permit(
       :status, :role, :member_type, :tag_list,
-      child_relationships_attributes: [:id, :child_unit_membership_id, :_destroy],
+      child_relationships_attributes:  [:id, :child_unit_membership_id, :_destroy],
       parent_relationships_attributes: [:id, :_destroy],
-      user_attributes: [:id, :first_name, :last_name, :phone, :email, :nickname]
+      user_attributes:                 [:id, :first_name, :last_name, :phone, :email, :nickname]
     )
   end
 
@@ -129,7 +131,8 @@ class UnitMembershipsController < ApplicationController
 
   def settings_params
     params.require(:settings).permit(
-      communication: [:via_email, :via_sms, :receives_event_invitations]
+      communication: [:via_email, :via_sms, :receives_event_invitations, :receives_all_rsvps]
     )
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -59,8 +59,6 @@ class Task < ApplicationRecord
     schedule.next_occurrence(last_ran_at || 1.week.ago)
   end
 
-  # set `last_ran_at`
-  #
   def set_high_watermark
     update! last_ran_at: DateTime.now
   end

--- a/app/models/unit_membership.rb
+++ b/app/models/unit_membership.rb
@@ -72,7 +72,8 @@ class UnitMembership < ApplicationRecord
       via_email:                  true,
       via_sms:                    false,
       event_organizer_digest:     true,
-      receives_event_invitations: false
+      receives_event_invitations: false,
+      receives_all_rsvps:         false
     }
     s.key :policy, defaults: { youth_rsvps: false }
     s.key :alerts
@@ -83,7 +84,8 @@ class UnitMembership < ApplicationRecord
 
   def child_of?(candidate)
     return parents.include?(candidate) if candidate.is_a?(UnitMembership)
-    return parents.map(&:user).include?(candidate) if candidate.is_a?(User)
+
+    parents.map(&:user).include?(candidate) if candidate.is_a?(User)
   end
 
   def siblings
@@ -112,6 +114,10 @@ class UnitMembership < ApplicationRecord
 
   def contactable_object
     user
+  end
+
+  def receives_event_rsvps?
+    settings(:communication).receives_all_rsvps || event_organizers.any?
   end
 
   def smsable?

--- a/app/tasks/event_organizer_digest_task.rb
+++ b/app/tasks/event_organizer_digest_task.rb
@@ -4,11 +4,6 @@
 # containing all RSVPs, flagging those that are new within
 # the last 24 hours.
 class EventOrganizerDigestTask < UnitTask
-  # def initialize(unit)
-  #   @unit = unit
-  #   super
-  # end
-
   def description
     "Daily digest for event organizers"
   end
@@ -16,7 +11,7 @@ class EventOrganizerDigestTask < UnitTask
   def perform
     Time.zone = unit.settings(:locale).time_zone
     unit.members.each do |member|
-      next unless member.event_organizers.present?
+      next unless member.receives_event_rsvps?
 
       notifier = MemberNotifier.new(member)
       notifier.send_event_organizer_digest(last_ran_at)

--- a/app/views/unit_memberships/partials/modal/_communication_settings_fields.slim
+++ b/app/views/unit_memberships/partials/modal/_communication_settings_fields.slim
@@ -5,8 +5,6 @@ div.pt-4
   = label_tag :communication_preferences, label, class: "block mb-2 font-bold"
 
   .py-1
-
-
     = switch( "settings[communication]", "via_email",
           { label: "Via email",
             checked: member.contactable?(via: :email) && member.settings(:communication).via_email == "true",
@@ -23,6 +21,17 @@ div.pt-4
           "true", "false" ) 
 
 div.pt-4
+  h4.font-bold.mb-2 = t(".notifications")
+
+  .py-1
+    = switch( "settings[communication]", "receives_all_rsvps",
+          { label: t(".receives_all_rsvps"),
+            checked: member.settings(:communication).receives_all_rsvps == "true",
+            data: {  },
+            disabled: !member.contactable? },
+          "true", "false" )
+
+  .py-1
     = render partial: "components/switch",
              locals: { object_name: object_name,
                        label: "Receive event invitations via email 14 days before event",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -728,6 +728,13 @@ en:
 
     notices:
       update_success: "Your unit profile has been updated"
+  
+  unit_memberships:
+    partials:
+      modal:
+        communication_settings_fields:
+          notifications: "Notifications"
+          receives_all_rsvps: "RSVPs for all events"
 
   unit_membership_profiles:
     index:

--- a/db/seeds/development/unit_memberships.seeds.rb
+++ b/db/seeds/development/unit_memberships.seeds.rb
@@ -1,9 +1,7 @@
-# frozen_string_literal: true
-
-after 'development:units', 'development:users' do
+after "development:units", "development:users" do
   unit = Unit.first
   User.all.each do |user|
-    role = user.email == 'admin@scoutplan.org' ? 'admin' : 'member'
-    user.unit_memberships.create(unit: unit, role: role)
+    role = user.email == "admin@scoutplan.org" ? "admin" : "member"
+    user.unit_memberships.create(unit: unit, role: role, member_type: "adult")
   end
 end

--- a/db/seeds/development/users.seeds.rb
+++ b/db/seeds/development/users.seeds.rb
@@ -3,63 +3,63 @@
 User.destroy_all
 
 bob = User.create!(
-  email: 'admin@scoutplan.org',
-  password: 'password',
-  password_confirmation: 'password',
-  first_name: 'Bob',
-  last_name: 'Dobalina',
-  phone: '555-1212',
-  type: :adult
+  email:                 "admin@scoutplan.org",
+  password:              "password",
+  password_confirmation: "password",
+  first_name:            "Bob",
+  last_name:             "Dobalina",
+  phone:                 "999-555-1212",
+  type:                  :adult
 )
 
 anne = User.create!(
-  email: 'anne@scoutplan.org',
-  password: 'password',
-  password_confirmation: 'password',
-  first_name: 'Anne',
-  last_name: 'Avery',
-  phone: '555-1212',
-  type: :youth
+  email:                 "anne@scoutplan.org",
+  password:              "password",
+  password_confirmation: "password",
+  first_name:            "Anne",
+  last_name:             "Avery",
+  phone:                 "999-555-1212",
+  type:                  :youth
 )
 
 brian = User.create!(
-  email: 'brian@scoutplan.org',
-  password: 'password',
-  password_confirmation: 'password',
-  first_name: 'Brian',
-  last_name: 'Bosworth',
-  phone: '555-1212',
-  type: :adult
+  email:                 "brian@scoutplan.org",
+  password:              "password",
+  password_confirmation: "password",
+  first_name:            "Brian",
+  last_name:             "Bosworth",
+  phone:                 "999-555-1212",
+  type:                  :adult
 )
 
 debbie = User.create!(
-  email: 'debbie@scoutplan.org',
-  password: 'password',
-  password_confirmation: 'password',
-  first_name: 'Debbie',
-  last_name: 'Doolittle',
-  phone: '555-1212',
-  type: :youth
+  email:                 "debbie@scoutplan.org",
+  password:              "password",
+  password_confirmation: "password",
+  first_name:            "Debbie",
+  last_name:             "Doolittle",
+  phone:                 "999-555-1212",
+  type:                  :youth
 )
 
 eric = User.create!(
-  email: 'eric@scoutplan.org',
-  password: 'password',
-  password_confirmation: 'password',
-  first_name: 'Eric',
-  last_name: 'Einstein',
-  phone: '555-1212',
-  type: :adult
+  email:                 "eric@scoutplan.org",
+  password:              "password",
+  password_confirmation: "password",
+  first_name:            "Eric",
+  last_name:             "Einstein",
+  phone:                 "999-555-1212",
+  type:                  :adult
 )
 
 timmy = User.create!(
-  email: 'timmy@scoutplan.org',
-  password: 'password',
-  password_confirmation: 'password',
-  first_name: 'Timmy',
-  last_name: 'Dobalina',
-  phone: '555-1212',
-  type: :youth
+  email:                 "timmy@scoutplan.org",
+  password:              "password",
+  password_confirmation: "password",
+  first_name:            "Timmy",
+  last_name:             "Dobalina",
+  phone:                 "999-555-1212",
+  type:                  :youth
 )
 
 bob.child_relationships.create!(child: timmy)

--- a/spec/notifications/event_rsvp_digest_spec.rb
+++ b/spec/notifications/event_rsvp_digest_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe MemberNotifier do
+  before do
+    Time.zone = "America/New_York"
+    @event_organizer = FactoryBot.create(:unit_membership)
+    @unit = @event_organizer.unit
+    @event = FactoryBot.create(:event, :requires_rsvp, unit: @unit)
+    @event.organizers.create!(member: @event_organizer, assigned_by: @event_organizer)
+    @event.rsvps.create!(member: @event_organizer, respondent: @event_organizer, response: "accepted")
+    @task = @unit.tasks.create!(key: "event_organizer_digest", type: "EventOrganizerDigestTask")
+  end
+
+  it "sends an email to the event organizer" do
+    expect { @task.perform }.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+  end
+
+  it "also sends an email to an 'All RSVPs' recipient" do
+    @unit_admin = FactoryBot.create(:unit_membership, unit: @unit, role: :admin)
+    @unit_admin.settings(:communication).receives_all_rsvps = "true"
+    @unit_admin.save!
+
+    5.times do
+      FactoryBot.create(:unit_membership, unit: @unit)
+    end
+
+    expect { @task.perform }.to have_enqueued_job(ActionMailer::MailDeliveryJob).twice
+  end
+end


### PR DESCRIPTION
- Previously, event RSVP digests were only generated for event organizers
- New toggle on member page enables RSVP digest for all events
- Corresponding specs
- Closes #1615