### PR TITLE
Adult-only message modifier

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -80,6 +80,8 @@ class MessagesController < UnitContextController
   def commit
     return unless (key = params[:key]).present?
 
+    ap params[:member_type]
+
     type, id = key.split("_")
     @recipients = case type
                   when "membership"
@@ -94,6 +96,7 @@ class MessagesController < UnitContextController
                     end
                   end
 
+    @recipients = @recipients.select(&:adult?) if params[:member_type] == "adult"
     @recipients = @recipients.map { |m| CandidateMessageRecipient.new(m, :committed, "") }
 
     # find parents of youth members

--- a/app/javascript/controllers/message_form_controller.js
+++ b/app/javascript/controllers/message_form_controller.js
@@ -192,12 +192,14 @@ export default class extends Controller {
     lastElem.remove();
   }
 
-  async commit() {
+  async commit(event) {
+    console.log(event);
     this.queryInputTarget.placeholder = "";
     const current = this.addressBookTarget.querySelector(".selected");
     const recipientTags = this.recipientListTarget.querySelectorAll(".recipient");
     const memberIds = Array.from(recipientTags).map((tag) => { return tag.dataset.recipientId; });
-    const body = { "key": current.dataset.key, "member_ids": memberIds }
+    const body = { "key": current.dataset.key, "member_ids": memberIds };
+    if (event.metaKey || event.ctrlKey || event.shiftKey) { body["member_type"] = "adult"; }
     await post(`/u/${this.unitIdValue}/messages/commit`, { body: body, responseKind: "turbo-stream" });    
 
     this.markAsDirty();


### PR DESCRIPTION
- Holding down the Command, Windows, or Shift key when clicking an item in the search result list will limit recipients to only adults
- Closes #1633