### PR TITLE
Fix calendar javascript

### DIFF
--- a/app/views/events/calendar.html.slim
+++ b/app/views/events/calendar.html.slim
@@ -140,7 +140,7 @@ javascript:
   function setupCalendarClicks() {
     document.querySelectorAll(".cal-cell").forEach(function(elem) {
       elem.addEventListener("dblclick", function(elem) {
-        var targetDate = elem.target.dataset.calDate;
+        var targetDate = elem.currentTarget.dataset.calDate;
         console.log(targetDate);
         url = "#{new_unit_event_path(@unit)}" + "?date=" + targetDate;
         window.location.href = url;


### PR DESCRIPTION
- Double-clicking on events within calendar cells no longer throws an error
- Fixes #1457