### PR TITLE
Restore EventRsvpConfirmationTask so we can graceful retire it.

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -215,7 +215,7 @@ class Event < ApplicationRecord
   end
 
   def non_invitees
-    unit.unit_memberships.joins(:user).status_registered - unit_memberships
+    unit.unit_memberships.joins(:user).status_registered.order("users.last_name, users.first_name") - unit_memberships
   end
 
   def primary_location

--- a/app/tasks/event_organizer_digest_task.rb
+++ b/app/tasks/event_organizer_digest_task.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Recurring task to send daily reminders to event organizers
+# containing all RSVPs, flagging those that are new within
+# the last 24 hours.
+class EventOrganizerDigestTask < UnitTask
+  def description
+    "Daily digest for event organizers"
+  end
+
+  def perform
+    Time.zone = unit.settings(:locale).time_zone
+    unit.members.each do |member|
+      next unless member.receives_event_rsvps?
+
+      notifier = MemberNotifier.new(member)
+      notifier.send_event_organizer_digest(last_ran_at)
+    end
+    super
+  end
+
+  def setup_schedule
+    return if schedule_hash.present?
+
+    evening_rule = IceCube::Rule.daily.hour_of_day(19).minute_of_hour(0)
+    schedule.start_time = DateTime.now.in_time_zone
+    schedule.add_recurrence_rule evening_rule
+
+    save_schedule
+  end
+end

--- a/spec/mailers/event_rsvp_confirmation_mailer_spec.rb
+++ b/spec/mailers/event_rsvp_confirmation_mailer_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe EventRsvpConfirmationMailer, type: :mailer do
+  before do
+    @rsvp = FactoryBot.create(:event_rsvp)
+    @event = @rsvp.event
+    @unit = @event.unit
+    @organizer = FactoryBot.create(:member, :adult, unit: @unit)
+    @event.event_organizers.create!(unit_membership: @organizer, assigned_by: @organizer)
+  end
+
+  describe "event_rsvp_confirmation" do
+    it "works" do
+      expect { EventRsvpConfirmationMailer.with(event_rsvp: @rsvp, recipient: @organizer).event_rsvp_confirmation.deliver_now }.not_to raise_error
+    end
+  end
+end

--- a/spec/models/event_rsvp_confirmation_text.rb
+++ b/spec/models/event_rsvp_confirmation_text.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe EventRsvpConfirmationText, type: :model do
+  it "instantiates" do
+    expect(EventRsvpConfirmationText.new(FactoryBot.create(:event_rsvp), FactoryBot.create(:member))).to be_a(EventRsvpConfirmationText)
+  end
+end


### PR DESCRIPTION
Authored test to capture the error we were seeing in the EventRsvpConfirmationText model Restore ordering of unit members on the Dashboard.