### PR TITLE
RSVP run time

### DIFF
--- a/app/models/event/remindable.rb
+++ b/app/models/event/remindable.rb
@@ -12,14 +12,14 @@ module Event::Remindable
   def enqueue_reminder_job!
     return unless published? && !ended?
 
-    run_time = unit.in_business_hours(starts_at - REMINDER_LEAD_TIME)
+    run_time = unit.in_business_hours(rsvp_closes_at - REMINDER_LEAD_TIME)
     EventReminderJob.set(wait_until: run_time).perform_later(id, updated_at)
   end
 
   def enqueue_last_call_job!
     return unless published? && !ended? && requires_rsvp?
 
-    run_time = unit.in_business_hours(starts_at - LAST_CALL_LEAD_TIME)
+    run_time = unit.in_business_hours(rsvp_closes_at - LAST_CALL_LEAD_TIME)
     RsvpLastCallJob.set(wait_until: run_time).perform_later(id, updated_at)
   end
 

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -92,14 +92,12 @@ class Unit < ApplicationRecord
   end
 
   def business_hours
-    [9, 18]
+    [9, 18] # 9am to 6pm
   end
 
   # given a datetime, returns the nearest datetime that is within business hours
   # rubocop:disable Metrics/AbcSize
   def in_business_hours(datetime)
-    return datetime unless ENV["RAILS_ENV"] == "production"
-
     if datetime.in_time_zone(time_zone).hour < business_hours.first
       datetime.in_time_zone(time_zone).change(hour: business_hours.first, min: 0, sec: 0).utc
     elsif datetime.in_time_zone(time_zone).hour >= business_hours.last

--- a/spec/concerns/event/remindable_spec.rb
+++ b/spec/concerns/event/remindable_spec.rb
@@ -2,17 +2,27 @@ require "rails_helper"
 
 RSpec.describe Event::Remindable, type: :concern do
   before do
-    @event = FactoryBot.create(:event, :published, :requires_rsvp)
+    # @event = FactoryBot.create(:event, :published, :requires_rsvp)
+    # @unit = @event.unit
+    @unit = FactoryBot.create(:unit)
+    Time.zone = @unit.time_zone
   end
 
   describe "methods" do
     describe "callbacks" do
       it "enqueues an EventReminderJob" do
-        expect { FactoryBot.create(:event, :published, :requires_rsvp)}.to have_enqueued_job(EventReminderJob)
+        expect { FactoryBot.create(:event, :published, :requires_rsvp) }.to have_enqueued_job(EventReminderJob)
       end
 
       it "enqueues an RsvpLastCallJob" do
-        expect { FactoryBot.create(:event, :published, :requires_rsvp) }.to have_enqueued_job(RsvpLastCallJob)
+        starts_at = 4.days.from_now
+        ends_at = 5.days.from_now
+        rsvp_closes_at = 3.days.from_now.at_end_of_day
+        last_call_lead_time = rsvp_closes_at - Event::Remindable::LAST_CALL_LEAD_TIME
+        rsvp_last_call_at = @unit.in_business_hours(last_call_lead_time)
+
+        expect { FactoryBot.create(:event, :published, :requires_rsvp, unit: @unit, starts_at: starts_at, ends_at: ends_at, rsvp_closes_at: rsvp_closes_at) }
+          .to have_enqueued_job(RsvpLastCallJob).on_queue("default").at(rsvp_last_call_at)
       end
     end
   end


### PR DESCRIPTION
RSVP Last Call job was erroneously triggered as a function of the event's start time. It should be a function of the rsvp_closes_at value.

- Failing spec
- Fix for the above; spec passes
- Closes #1750