### PR TITLE
Password reset barfs on confirmation mismatch

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -43,10 +43,10 @@ class ProfilesController < ApplicationController
   end
 
   def perform_password_update
-    if @member.update!(member_params.merge(password_changed_at: Time.now))
+    if @member.update(member_params.merge(password_changed_at: Time.now))
       redirect_to root_path, notice: "Password updated"
     else
-      render "change_password"
+      render "security"
     end
   end
 

--- a/app/views/profiles/security.html.slim
+++ b/app/views/profiles/security.html.slim
@@ -30,10 +30,20 @@
             = uf.password_field :password_confirmation, class: "block w-full rounded border-stone-400 dark:bg-stone-800 dark:border-stone-500"
 
         footer.py-2
-          p.mb-6
-            i.fa-regular.fa-exclamation-triangle.mr-2.text-amber-500
-            | Changing #{possessive_name_or_pronoun(@member, @member)} password will sign 
-            | #{pronoun(@member, @member)} out of Scoutplan. #{pronoun(@member, @member).capitalize} can sign back in using 
-            | #{possessive_pronoun(@member, @member)} new password.
+          - if @member.errors.any?
+
+            ul.mb-6
+              - @member.errors.each do |error|
+                li
+                  i.fa-solid.fa-times-circle.mr-2.text-red-500
+                  / = error.details
+                  = error.full_message
+
+          - else
+            p.mb-6
+              i.fa-regular.fa-exclamation-triangle.mr-2.text-amber-500
+              | Changing #{possessive_name_or_pronoun(@member, @member)} password will sign 
+              | #{pronoun(@member, @member)} out of Scoutplan. #{pronoun(@member, @member).capitalize} can sign back in using 
+              | #{possessive_pronoun(@member, @member)} new password.
 
           = f.button("Change password", type: "submit", class: "block bg-green-600 text-white font-bold px-4 py-2 rounded")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -874,3 +874,16 @@ en:
       new:           "Add a page"
       no_wiki_pages: "You don't have any pages yet. "
       new_cta:       "Start one now"
+
+
+
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            password:
+              blank: "Your password can't be blank"
+              confirmation: "Your password and confirmation don't match"
+            password_confirmation:
+              # confirmation: "%{attribute} doesn't match"


### PR DESCRIPTION
- Remove bang (!) on update so it stops throwing errors
- Re-render the security page
- Fixes #1856