### PR TITLE
Event detail pages are incorrectly displaying to logged-out users

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -124,7 +124,7 @@ class EventsController < UnitContextController
     @can_edit = policy(@event).edit?
     @can_organize = policy(@event).rsvps?
     @current_family = current_member&.family
-    if @event.requires_payment? && Flipper.enabled?(:payments, current_unit)
+    if @event.requires_payment? && Flipper.enabled?(:payments, current_unit) && @current_family.present?
       @payments = @event.payments.paid.where(unit_membership_id: @current_family.map(&:id))
       @family_rsvps = @event.rsvps.where(unit_membership_id: @current_family.map(&:id))
       @subtotal = (@family_rsvps.accepted.youth.count * @event.cost_youth) + (@family_rsvps.accepted.adult.count * @event.cost_adult)

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -2,7 +2,7 @@
 
 # Policy class governing Events and what members can do with them
 class EventPolicy < UnitContextPolicy
-  attr_accessor :event
+  attr_accessor :event, :membership
 
   def initialize(membership, event = nil)
     super
@@ -11,6 +11,8 @@ class EventPolicy < UnitContextPolicy
   end
 
   def show?(event = nil)
+    return false unless membership.present?
+
     @event = event if event.present?
     return true if admin?
     return true if @event.organizer?(@membership)

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -43,6 +43,13 @@ describe "events", type: :feature do
       visit(path)
       expect(page).to have_current_path(path)
     end
+
+    it "denies access to an event" do
+      @unit.update!(public_calendar: true)
+      path = unit_event_path(@unit, @published_event)
+      visit(path)
+      expect(page).not_to have_current_path(path)
+    end
   end
 
   describe "events index" do


### PR DESCRIPTION
...and throwing an error in the process

- Update EventPolicy to deny page access unless logged in
- Strengthen guard clause in EventController to prevent errors
- Update spec (failed, then passing)