### PR TITLE
Redesigned event list view to show meeting links in the same place as…

### DIFF
--- a/app/models/event/onlineable.rb
+++ b/app/models/event/onlineable.rb
@@ -6,23 +6,35 @@ module Event::Onlineable
   JOIN_LEAD_TIME = 15.minutes.freeze
 
   included do
-    validate :valid_website_url?
+    validate :valid_online_url?
+  end
+
+  def online?
+    online_url.present?
   end
 
   def joinable?
     starts_at < JOIN_LEAD_TIME.from_now && ends_at.future?
   end
 
-  def hostname
-    URI.parse(website).host
+  def online_url
+    online_location&.url || website
   end
 
-  def valid_website_url?
-    return false if website.blank?
+  def online_location
+    @online_location || event_locations.find_by(location_type: "online")
+  end
 
-    uri = URI.parse(website)
+  def hostname
+    URI.parse(online_url).host
+  end
+
+  def valid_online_url?
+    return false if online_url.blank?
+
+    uri = URI.parse(online_url)
     uri.host.present?
   rescue URI::InvalidURIError
-    errors.add(:website, "Invalid URL")
+    errors.add(:online_url, "Invalid URL")
   end
 end

--- a/app/views/events/_event.slim
+++ b/app/views/events/_event.slim
@@ -28,28 +28,29 @@ li.event(class="#{row_classes(event)}" id="#{dom_id(event)}")
 
 
       // 2 title, tags, description, location
-      = link_to href,
-                class: "py-2 block shrink grow",
-                name:  event.id,
-                data:  { month: event.starts_at.month,
-                        year: event.starts_at.year,
-                        turbo_frame: "modal", turbo_action: "advance" } do
+      div
+        = link_to href,
+                  class: "pt-2 block shrink grow",
+                  name:  event.id,
+                  data:  { month: event.starts_at.month,
+                          year: event.starts_at.year,
+                          turbo_frame: "modal", turbo_action: "advance" } do
 
-          h4.text-xl.font-semibold.event-title.text-ellipsis
-            i.fa-solid.fa-xs.fa-fw.mr-1(class="fa-#{event&.category&.glyph}" style="color: #{event&.category&.color}")
-            = event.title
+            h4.text-xl.font-semibold.event-title.text-ellipsis
+              i.fa-solid.fa-xs.fa-fw.mr-1(class="fa-#{event&.category&.glyph}" style="color: #{event&.category&.color}")
+              = event.title
 
-          = render partial: "events/partials/event_row/title_badge", locals: { event: event }
-          = render partial: "events/partials/index/short_description", locals: { event: event }
-          = render partial: "events/event_location", locals: { event: event }
-          = render partial: "events/event_cost", locals: { event: event }
+        = render partial: "events/partials/event_row/title_badge", locals: { event: event }
+        = render partial: "events/partials/index/short_description", locals: { event: event }
+        = render partial: "events/event_location", locals: { event: event }
+        = render partial: "events/event_cost", locals: { event: event }
+        = render partial: "events/partials/event_row/online", locals: { event: event }
 
       - if current_user
-        .third.flex.flex-col
+        .ml-auto.third.flex.flex-col
           - if event.organizable? && EventPolicy.new(current_member, event).rsvps? && params[:list_view] != "member"
             = render partial: "events/partials/event_row/organize", locals: { event: event }
           - elsif event.requires_rsvp
             .w-48
               = render partial: "events/partials/event_row/family_rsvp_link", locals: { event: event }
 
-          = render partial: "events/partials/event_row/online", locals: { event: event }

--- a/app/views/events/_event_location.slim
+++ b/app/views/events/_event_location.slim
@@ -1,6 +1,5 @@
+- return if event.online? || event.event_locations.blank?
+
 p.event-location.text-sm.text-stone-500.mt-2
-  - if event.online
-    .link-placeholder.h-5
-  - elsif location = event.location
-    i.fa-regular.fa-map-marker-alt.fa-fw.mr-1
-    span = event.location
+  i.fa-regular.fa-map-marker-alt.fa-fw.mr-1
+  span = event.location

--- a/app/views/events/partials/event_row/_online.slim
+++ b/app/views/events/partials/event_row/_online.slim
@@ -1,27 +1,6 @@
-- return unless event.online && website = event.website.presence
+- return unless event.online?
 
-.flex.flex-row.gap-3.items-center.my-1
-  div.-ml-1.relative.dropdown.group
-    = link_to "#",
-              class: "dropdown-button px-1 py-1 rounded font-semibold hover:bg-blue-100 dark:hover:bg-blue-900 group-[&.menu-open]:bg-blue-100 dark:group-[&.menu-open]:bg-blue-600" do
-      i.fa-solid.fa-video.mr-2.text-indigo-600.dark:text-indigo-300
-      = event.hostname
-      i.fa-solid.fa-chevron-down.ml-1
-
-    .dropdown-menu.absolute.top-full.w-full.z-50.drop-shadow.rounded.ml-2.mt-2.bg-blue-800.dark:bg-stone-900.border.border-stone-400.dark:border-stone-700
-      = link_to website,
-                class: "block px-4 py-1 hover:bg-blue-700 text-blue-50",
-                target: "_new"
-        = t("events.show.captions.open_link")
-
-      div(data-controller="clipboard" data-clipboard-text-value="#{website}")
-        = link_to "#",
-                  class: "block px-4 py-1 hover:bg-blue-700 text-blue-50 z-50",
-                  data: { action: "clipboard#copy" }
-          = t("events.show.captions.copy_link")
-
-  - if event.joinable?
-    = link_to t("events.show.captions.join"), website,
-              class: "bg-blue-800 text-blue-50 hover:bg-blue-700 rounded block px-4 py-2 font-bold",
-              target: "_new"
+= link_to event.online_url, class: "text-sm text-blue-500 underline" do
+  i.fa-solid.fa-video.mr-2
+  = event.hostname
 


### PR DESCRIPTION
… physical locations.

Turned out, evnet display wasn't honoring online event locations and only honoring the old explicit online meeting fields. Hence, the Event and Onlineable models were refactored to handle both. Eventually we'll want to migrate legacy online events to the new event_locations construct.

- Closes #2070